### PR TITLE
fix: correct getResourceByHash API call and error code name

### DIFF
--- a/evernote_mcp/client.py
+++ b/evernote_mcp/client.py
@@ -273,13 +273,16 @@ class EvernoteMCPClient(BaseEvernoteClient):
                              with_recognition: bool = False,
                              with_attributes: bool = True,
                              with_alternate_data: bool = False) -> Resource:
-        """Get resource by content hash."""
+        """Get resource by content hash.
+
+        Note: The Evernote API's getResourceByHash does not support withAttributes parameter.
+        Attributes are always included in the response.
+        """
         return self.note_store.getResourceByHash(
             note_guid,
             content_hash,
             withData=with_data,
             withRecognition=with_recognition,
-            withAttributes=with_attributes,
             withAlternateData=with_alternate_data,
         )
 

--- a/evernote_mcp/util/error_handler.py
+++ b/evernote_mcp/util/error_handler.py
@@ -63,7 +63,7 @@ def _get_edam_user_error_message(e: EDAMUserException) -> str:
         EDAMErrorCode.BAD_DATA_FORMAT: "Invalid data format",
         EDAMErrorCode.DATA_CONFLICT: "Data conflict - resource already exists",
         EDAMErrorCode.DATA_REQUIRED: "Required data is missing",
-        EDAMErrorCode.ENML_VALIDATION_FAILURE: "Invalid note content format",
+        EDAMErrorCode.ENML_VALIDATION: "Invalid note content format",
         EDAMErrorCode.LIMIT_REACHED: "Account limit reached",
         EDAMErrorCode.QUOTA_REACHED: "Upload quota reached",
         EDAMErrorCode.PERMISSION_DENIED: "Permission denied",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "evernote-mcp"
-version = "0.3.0"
+version = "0.3.1"
 description = "Model Context Protocol (MCP) server for Evernote operations"
 authors = [
     { name = "king", email = "king@example.com" }


### PR DESCRIPTION
## Summary
- Remove unsupported `withAttributes` parameter from `getResourceByHash` API call
- Fix `EDAMErrorCode.ENML_VALIDATION_FAILURE` to correct `ENML_VALIDATION`
- Bump version to 0.3.1

## Test plan
- [x] Verified API signature matches Evernote SDK
- [x] Python syntax check passed
- [x] Published to PyPI (v0.3.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)